### PR TITLE
Revert "Don't provision aws client with keys; rely on IAM roles in EC2"

### DIFF
--- a/lib/opsworks.coffee
+++ b/lib/opsworks.coffee
@@ -4,7 +4,11 @@
 AWS = require('aws-sdk')
 Q = require('q')
 
+access = process.env.AWS_ACCESS_KEY_ID
+secret = process.env.AWS_SECRET_ACCESS_KEY
 region = process.env.AWS_REGION
+
+AWS.config.update(accessKeyId: access, secretAccessKey: secret)
 
 class OpsWorks
   # You have to initialize with the region here, not in the update config


### PR DESCRIPTION
This reverts commit 6004e748a26d5f67f9ecaee6b989432e57272155.
