### PR TITLE
Support API Gateway apps

### DIFF
--- a/lib/api-gateway.coffee
+++ b/lib/api-gateway.coffee
@@ -1,0 +1,18 @@
+Q = require('q')
+request = require('request')
+
+class ApiGateway
+  @fetchBuildVersion = (app) ->
+    def = Q.defer()
+    request(app.api_gateway_url + '/version', (error, response, body) ->
+      if error
+        def.reject(error)
+      else if response.statusCode != 200
+        def.reject("Got failure status code: " + response.statusCode)
+      else
+        app.build = body
+        def.resolve(app)
+    )
+    return def.promise
+
+module.exports = ApiGateway

--- a/scripts/builds.coffee
+++ b/scripts/builds.coffee
@@ -12,6 +12,7 @@ opsworks_apps = require(process.env.APPS_CONFIG_FILE)
 # The supporting classes that provided limited queries that allow hubot
 # to respond
 OpsWorks = require('../lib/opsworks')
+ApiGateway = require('../lib/api-gateway')
 Circle = require('../lib/circle')
 Dynamo = require('../lib/dynamo')
 
@@ -45,6 +46,8 @@ module.exports = (robot) ->
       for app, data of env_data
         if 'opsworks_id' in Object.keys data
           OpsWorks.fetchBuildVersion(data)
+        else if 'api_gateway_url' in Object.keys data
+          ApiGateway.fetchBuildVersion(data)
         else
           Dynamo.fetchBuildVersion(data)
     )

--- a/scripts/diff.coffee
+++ b/scripts/diff.coffee
@@ -6,6 +6,7 @@
 Q = require('q')
 request = require('request')
 OpsWorks = require('../lib/opsworks')
+ApiGateway = require('../lib/api-gateway')
 Circle = require('../lib/circle')
 Dynamo = require('../lib/dynamo')
 
@@ -49,6 +50,8 @@ module.exports = (robot) ->
       for app, data of env_data
         if 'opsworks_id' in Object.keys data
           OpsWorks.fetchBuildVersion(data)
+        else if 'api_gateway_url' in Object.keys data
+          ApiGateway.fetchBuildVersion(data)
         else
           Dynamo.fetchBuildVersion(data)
     )


### PR DESCRIPTION
Support fetching versions from apps running behind API Gateway, such as our lambda functions, by GETting their /version endpoint.