### PR TITLE
Support new version format

### DIFF
--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -35,7 +35,14 @@ function fetchBuildVersion(app, stack) {
     }
 
     let { APP: { version } } = JSON.parse(decodeURIComponent($meta.attr('content')));
-    return version.split('-')[0];
+    let parts = version.split('-');
+    if (parts.length === 3) {
+      // Old format <build num>-<branch>-<commit hash>
+      return parts[0];
+    } else {
+      // New format <major>.<minor>.<bugfix>-<build num>
+      return parts[1];
+    }
   });
 }
 

--- a/tests/lib/dynamo-test.js
+++ b/tests/lib/dynamo-test.js
@@ -14,6 +14,15 @@ const html = `
   <html>
     <head>
       <meta charset="utf-8">
+      <meta name="my-app/config/environment" content="%7B%22modulePrefix%22%3A%22my-app%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22/%22%2C%22routerRootURL%22%3A%22/officeaction/shell/%22%2C%22locationType%22%3A%22history%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22name%22%3A%22my-app%22%2C%22version%22%3A%223.1.0-123%22%7D%2C%22ember-cli-mirage%22%3A%7B%22enabled%22%3Afalse%2C%22usingProxy%22%3Afalse%2C%22useDefaultPassthroughs%22%3Atrue%7D%2C%22something%22%3A%22test%22%2C%22exportApplicationGlobal%22%3Afalse%7D"/>
+    </head>
+  </html>
+`;
+
+const htmlOldVersion = `
+  <html>
+    <head>
+      <meta charset="utf-8">
       <meta name="my-app/config/environment" content="%7B%22modulePrefix%22%3A%22my-app%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22/%22%2C%22routerRootURL%22%3A%22/officeaction/shell/%22%2C%22locationType%22%3A%22history%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22name%22%3A%22my-app%22%2C%22version%22%3A%22123-master-891eaa0a6863069d2e5f567c68d059fbbe134ff6+891eaa0a%22%7D%2C%22ember-cli-mirage%22%3A%7B%22enabled%22%3Afalse%2C%22usingProxy%22%3Afalse%2C%22useDefaultPassthroughs%22%3Atrue%7D%2C%22something%22%3A%22test%22%2C%22exportApplicationGlobal%22%3Afalse%7D"/>
     </head>
   </html>
@@ -56,6 +65,19 @@ describe('dynamo', function() {
         assert.deepEqual(stub.getCall(1).args[0], {
           TableName: 'testtable',
           Key: { version_id: { S: '/prod/current' } }, // eslint-disable-line camelcase
+          ProjectionExpression: 'html'
+        });
+        assert.equal(buildNum, "123");
+      });
+    });
+
+    it('works with the old version format', function() {
+      let stub = sandbox.stub(dynamo, 'getItem').returns(resolve({ Item: { html: { S: htmlOldVersion } } }));
+
+      return fetchBuildVersion(app, 'stage').then((buildNum) => {
+        assert.deepEqual(stub.getCall(0).args[0], {
+          TableName: 'testtable',
+          Key: { version_id: { S: '/stage/current' } }, // eslint-disable-line camelcase
           ProjectionExpression: 'html'
         });
         assert.equal(buildNum, "123");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,9 +1232,9 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-jquery@^2.1.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
+jquery@^3.1.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
 
 js-tokens@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
We're going to be switching apps (at least apps that also build for electron) to using a more standard version format -- 1.2.3-456 where '456' is the circle build number. This change allows hubot to support both.